### PR TITLE
[feat] 검색 패싯 정렬

### DIFF
--- a/chalicelib/business/search/business.py
+++ b/chalicelib/business/search/business.py
@@ -136,9 +136,9 @@ class AsyncSearchBusiness(SearchBusinessIfs):
         products = sorted(products, key=lambda x: x.price)
 
         response = SearchResultResponseDto(
-            categories=categories,
-            events=events,
-            brands=brands,
+            categories=sorted(categories, key=lambda x: x.id),
+            events=sorted(events, key=lambda x: x.id),
+            brands=sorted(brands, key=lambda x: x.id),
             products=products,
             products_count=len(products),
         )

--- a/tests/business/test_search.py
+++ b/tests/business/test_search.py
@@ -85,3 +85,7 @@ def test_search(constant_brand_service, product_service, search_service, loop):
         if product.event_price is not None:
             assert product.event_price < product.price
     assert res.products_count == len(res.products)
+
+    assert sorted(res.categories, key=lambda x: x.id) == res.categories
+    assert sorted(res.brands, key=lambda x: x.id) == res.brands
+    assert sorted(res.events, key=lambda x: x.id) == res.events


### PR DESCRIPTION
`categories`, `brands`, `events`를 id 순서로 정렬해서 내리기